### PR TITLE
bugfix/get-config problem with TEXT type

### DIFF
--- a/src/libphoto2/photo_camera.cpp
+++ b/src/libphoto2/photo_camera.cpp
@@ -510,7 +510,7 @@ bool photo_camera::photo_camera_get_config( const std::string& param, char** val
     {
       gp_context_error( context_, "Failed to retrieve value of text widget %s.", param.c_str() );
     }
-    *value = txt;
+    sprintf(*value, "%s", txt);
     break;
 
   case GP_WIDGET_RANGE: // float


### PR DESCRIPTION
fixes bosch-ros-pkg/photo#7

Fix a problem where, when trying to call the /get-config
service on a text field, you would first get wrong data,
and on the second call the node would crash.